### PR TITLE
Add svelte extension support for syntax highlighting

### DIFF
--- a/src/format/code.ts
+++ b/src/format/code.ts
@@ -16,6 +16,7 @@ enum LanguageMap {
 	env = "bash",
 	html = "markup",
 	sv = "svelte",
+	svelte = "svelte",
 	js = "javascript",
 	css = "css",
 	diff = "diff",


### PR DESCRIPTION
@geoffrich noticed that the SvelteKit and Svelte docs are inconsistent. This would let us standardize on `svelte` while not breaking the existing docs in the interim